### PR TITLE
Restrict filesystem access to ~/.doomsday

### DIFF
--- a/net.dengine.Doomsday.json
+++ b/net.dengine.Doomsday.json
@@ -10,7 +10,7 @@
         "--share=ipc",
         "--share=network",
         "--device=dri",
-        "--filesystem=home"
+        "--filesystem=home/.doomsday:create"
     ],
     "modules": [
         {


### PR DESCRIPTION
I'm not sure if more directories are required.
The file picker already seems to support portals.
Ideally doomsday would be updated to support `XDG_CONFIG_HOME`, `XDG_CACHE_HOME` etc.