### PR TITLE
Add device=all for gamepad access

### DIFF
--- a/net.dengine.Doomsday.json
+++ b/net.dengine.Doomsday.json
@@ -10,6 +10,7 @@
         "--share=ipc",
         "--share=network",
         "--device=dri",
+        "--device=all",
         "--filesystem=home"
     ],
     "modules": [


### PR DESCRIPTION
Unfortunately for gamepads device=all is our best option for gamepad access.
I left device=dri in place in hopes that device=input will be viable at some point.