### PR TITLE
Update runtime to from 5.15-24.08 to 5.15-25.08

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/net.dengine.Doomsday.json
+++ b/net.dengine.Doomsday.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.dengine.Doomsday",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-24.08",
+    "runtime-version": "5.15-25.08",
     "sdk": "org.kde.Sdk",
     "command": "doomsday",
     "finish-args": [
@@ -12,34 +12,29 @@
         "--device=dri",
         "--filesystem=home"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/doomsday/cmake",
+        "/lib/doomsday/pkgconfig",
+        "/share/doc",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
-        {
-            "name": "fluidsynth",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DLIB_SUFFIX=",
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-                "-Denable-aufile=NO",
-                "-Denable-ipv6=NO",
-                "-Denable-network=NO"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.3.5.tar.gz",
-                    "sha256": "f89e8e983ecfb4a5b4f5d8c2b9157ed18d15ed2e36246fa782f18abaea550e0d"
-                }
-            ]
-        },
+        "shared-modules/linux-audio/fluidsynth2.json",
         {
             "name": "doomsday",
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
                 "-DDE_PREFIX=/app",
                 "-DDENG_ENABLE_SDK=NO",
                 "-DDENG_BUILD=3685"
+            ],
+            "post-install": [
+                "install -Dm644 ../doomsday/{gpl-3.0.txt,lgpl-3.0.txt} -t $FLATPAK_DEST/share/licenses/$FLATPAK_ID/doomsday/"
             ],
             "sources": [
                 {


### PR DESCRIPTION
- Update the runtime version to 5.15-25.08
- Use Fluidsynth2 module from shared-modules
- Improve cleanup commands to remove the development-related files
- Install missing license files

The installed size reduced from 141 MB to 62 MB.

**Please don't forget to test before merging. I only tested with the Steam version of Doom.**